### PR TITLE
Power assert output enabled on the `gradle test` command line

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -44,6 +44,7 @@ tasks.withType(Test) {
   testLogging {
     // Show that tests are run in the command-line output
     events 'passed', 'failed'
-    showExceptions = false
+    showExceptions = true
+    exceptionFormat = 'full'
   }
 }


### PR DESCRIPTION
http://mrhaki.blogspot.com/2013/05/gradle-goodness-show-more-information.html

Example output:

```
Workshop1Spec > 1.2 - gString concatenation FAILED
    Condition not satisfied:

    gString == 'Hello Sterling Archer!'
    |       |
    |       false
    |       1 difference (95% similarity)
    |       Hello Sterling Archer(-)
    |       Hello Sterling Archer(!)
    Hello Sterling Archer
        at Workshop1Spec.1.2 - gString concatenation(Workshop1Spec.groovy:40)
```
